### PR TITLE
teiBody2HTML: add override for template headingNumberSuffix

### DIFF
--- a/data/xslt/tei/profiles/edirom-body/teiBody2HTML.xsl
+++ b/data/xslt/tei/profiles/edirom-body/teiBody2HTML.xsl
@@ -1317,4 +1317,23 @@
         </xsl:if>
     </xsl:template>
     <!-- /SAVED OLD TEI TEMPLATES TO MAKE THIS WORK -->
+    
+    
+    <!-- TEI Stylesheets 7.58.0 OVERRIDES -->
+    <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl" class="headings" type="string">
+        <desc>Override template from common_param.xsl</desc>
+        <desc>Punctuation to insert after a section number</desc>
+    </doc>
+    <xsl:template name="headingNumberSuffix">
+        <xsl:choose>
+            <xsl:when test="$prenumberedHeadings='true'">
+                <xsl:value-of select="$numberSpacer"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>.</xsl:text>
+                <xsl:value-of select="$numberSpacer"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    <!-- /TEI Stylesheets 7.58.0 OVERRIDES -->
 </xsl:stylesheet>


### PR DESCRIPTION
Do not append "." for $prenumberedHeadings='true'

## Description, Context and related Issue

The TEI Stylesheets have a parameter `prenumberedHeadings`. If set to `true`, section headings will get the value of their `@n` as their number. The plain output of `@n` (not being concatenated across the div hierarchy) implies the value being the complete heading number. Moreover, it is not clear which number divider is to be used. Consequently, no `.` should be appended.

## How Has This Been Tested?
TEI text with and without encoded heading numbers, with parameter set to true and false.

## Types of changes
- New feature (non-breaking change which adds functionality)

## Caveats

A pull request should be filed at the TEIC/Stylesheets repository.

## Overview
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Backend/blob/develop/CONTRIBUTING.md) document.
